### PR TITLE
Add some info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Devlabs        [![Build Status](https://travis-ci.org/bumbolt/devlabs.svg?branch=master)](https://travis-ci.org/bumbolt/devlabs)
 
-[Slack available](http://r-devlabs.slack.com) (devlabs-application channel)
+## Some links
+
+ * [Devlabs website](https://devlabs-admin.firebaseapp.com/devlabs/topics)
+ * [Slack channel](https://r-devlabs.slack.com/messages/devlabs-application)
+ * [Travis build](https://travis-ci.org/bumbolt/devlabs)
+
+
+## Getting Started
+
+The frontend is created using Angular, the backend is
+fairly vanilla java for the moment. To get started working
+on either one of those, check the [frontend README][1] or the
+[backend README][2].
+
+
+[1]: frontend/README.md
+[2]: backend/README.md

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,7 @@ commands below.
 
 ## Running unit tests
 
-`gralde test`
+`gradle test`
 
 
 ## Running the application

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,18 +2,27 @@
 
 ## Gradle wrapper
 
-The backend project has a buildin gradle (wrapper). You can use this by running `./gradlew` (Linux/OSX) or `gradlew` (Windows).
-Replace the `gradle` command with the appropriate wrapper command for your OS to run the commands below.
+The backend project uses [Gradle](https://gradle.org/) as 
+its build tool, but you do not have to install it yourself. 
+You can use the gradle wrapper that is included in this 
+project.
+
+The wrapper is executed by by running `./gradlew` (Linux/OSX)
+or `gradlew` (Windows).  Replace the `gradle` command with
+the appropriate wrapper command for your OS to run the 
+commands below.
+
 
 ## Building
 
 `gradle build`
 
+
 ## Running unit tests
 
 `gralde test`
 
-## Running the application
 
+## Running the application
 
 `gradle run`


### PR DESCRIPTION
Changes to main README:
 * Link to slack now points directly at the correct channel
 * Added link to production site
 * Added (extra) link to Travis
 * Added small setup section that links to the
   front-/backend README

Changes to backend README
 * Write a little more about the gradle wrapper
 * Some formatting